### PR TITLE
correct one mistake for dictionary generation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/DictionaryUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/DictionaryUtils.java
@@ -104,13 +104,15 @@ public class DictionaryUtils {
 		co.dictAbort = generateGUID();
 		co.dictOk = generateGUID();
 		co.dictFail = generateGUID();
-		co.dictId = generateGUID();
 		List<CodegenParameter> listParams = co.allParams;
 		for (CodegenParameter cp : listParams) {
 			cp = transferDataType(cp);
 			cp = verifyVariableExisting(cp, allExistingVariables);
 		}
-		removeExistingComponet(co);
+		co.dictId = removeExistingComponet(co);
+		if(co.dictId == null){
+			co.dictId = generateGUID();
+		}
 		if(null != co.returnType) {
 			CodegenParameter returnParam = constructReturnParam(co, moduleFolder + "/" + co.returnType + ".java");
 			returnParam = transferDataType(returnParam);
@@ -224,14 +226,16 @@ public class DictionaryUtils {
 		return map;
 	}
 	
-	private Document removeExistingComponet(CodegenOperation co) {
+	private String removeExistingComponet(CodegenOperation co) {
 		String actionName = co.operationIdCamelCase + "Action";
 		String xpath = "//module[@name = 'Rest Api']/component[@name='" + actionName + "']";
 		Node node = document.selectSingleNode(xpath);
+		String nodeId = null;
 		if(null != node) {
+			nodeId = node.valueOf("@id");
 			node.getParent().remove(node);
 		}
-		return document;
+		return nodeId;
 	}
 
 	/**


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

